### PR TITLE
Do not automount service account tokens for the OWA pods

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -401,7 +401,8 @@ func getSeedResources(oidcReplicas *int32, namespace string, shootAccessSecret *
 							}},
 						},
 					},
-					ServiceAccountName: constants.ApplicationName,
+					AutomountServiceAccountToken: pointer.Bool(false),
+					ServiceAccountName:           constants.ApplicationName,
 					Containers: []corev1.Container{{
 						Name:            constants.ApplicationName,
 						Image:           image.String(),
@@ -503,6 +504,7 @@ func getSeedResources(oidcReplicas *int32, namespace string, shootAccessSecret *
 				Namespace: namespace,
 				Labels:    getLabels(),
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		},
 		oidcDeployment,
 		&corev1.Service{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR explicitly states that service account tokens will not be mounted for the OWA pods running in the seed cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Service account tokens for the `oidc-webhook-authenticator` pods will no longer be automounted.
```
