### PR TITLE
Call verify step on release

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -30,7 +30,6 @@ gardener-extension-shoot-oidc-service:
         options:
           public_build_logs: true
     release:
-      steps: ~
       traits:
         version:
           preprocess: 'finalize'


### PR DESCRIPTION
**What this PR does / why we need it**:
My guess is that this was overwriting the base definition and this is why the `verify` step is not called on release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
