### PR TITLE
Fix name of generated tls secret data

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -306,6 +306,7 @@ func (a *actuator) getOrCreateTLSSecret(ctx context.Context, certificateConfig s
 
 	config := secrets.ControlPlaneSecretConfig{
 		CertificateSecretConfig: &certificateConfig,
+		Name:                    certificateConfig.Name,
 	}
 
 	controlPlane, err := config.GenerateControlPlane()


### PR DESCRIPTION
**What this PR does / why we need it**:
After vendoring g/g v1.43.2 a regression was introduced. This resulted in secrets with data keys of `.crt` and `.key` instead of `oidc-webhook-authenticator-tls.crt` and `oidc-webhook-authenticator-tls.key`. This PR fixes the name generation of the data keys. [reference](https://github.com/gardener/gardener/commit/6733cbb518020c931a3aab656750555483137f18#diff-3c51a57fca1f8609e5aa852f54d34b3cbfadf2e255b21b00877f70f033893ed8R146)
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
