### PR TITLE
Move e2e tests to a single package

### DIFF
--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package lifecycle
+package e2e_test
 
 import (
 	"context"
@@ -37,10 +37,11 @@ var _ = BeforeEach(func() {
 const projectNamespace = "garden-local"
 
 func defaultShootCreationFramework() *framework.ShootCreationFramework {
+	kubeconfigPath := os.Getenv("KUBECONFIG")
 	return framework.NewShootCreationFramework(&framework.ShootCreationConfig{
 		GardenerConfig: &framework.GardenerConfig{
 			ProjectNamespace:   projectNamespace,
-			GardenerKubeconfig: os.Getenv("KUBECONFIG"),
+			GardenerKubeconfig: kubeconfigPath,
 			SkipAccessingShoot: true,
 			CommonConfig:       &framework.CommonConfig{},
 		},

--- a/test/e2e/create_enable_delete_test.go
+++ b/test/e2e/create_enable_delete_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package lifecycle
+package e2e_test
 
 import (
 	"context"
@@ -16,9 +16,9 @@ import (
 
 var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = defaultShoot("hibernated-")
+	f.Shoot = defaultShoot("default-")
 
-	It("Create Shoot, Enable OIDC Extension, Hibernate and Delete Shoot", Label("good-case"), func() {
+	It("Create Shoot, Enable OIDC Extension, Delete Shoot", Label("good-case"), func() {
 		By("Create Shoot")
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
@@ -41,11 +41,6 @@ var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 		one := int32(1)
 		Expect(*depl.Spec.Replicas).To(BeNumerically(">=", one))
 		Expect(depl.Status.ReadyReplicas).To(BeNumerically(">=", one))
-
-		By("Hibernate Shoot")
-		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
-		defer cancel()
-		Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/create_enable_disable_delete_test.go
+++ b/test/e2e/create_enable_disable_delete_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package lifecycle
+package e2e_test
 
 import (
 	"context"

--- a/test/e2e/create_enable_disrupt_reconcile_delete_test.go
+++ b/test/e2e/create_enable_disrupt_reconcile_delete_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package lifecycle
+package e2e_test
 
 import (
 	"context"
@@ -52,7 +52,7 @@ var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 		By("Disrupt API Server")
 		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
-		breakAPIServerDepl(ctx, seedClient.Client(), shootSeedNamespace)
+		Expect(breakAPIServerDepl(ctx, seedClient.Client(), shootSeedNamespace)).To(Succeed())
 		Eventually(func() error {
 			return ensureNoRunningKubeAPIServerContainers(ctx, seedClient.Client(), shootSeedNamespace)
 		}, time.Minute*2, time.Second*2).Should(Succeed())

--- a/test/e2e/create_enable_hibernate_delete_test.go
+++ b/test/e2e/create_enable_hibernate_delete_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package lifecycle
+package e2e_test
 
 import (
 	"context"
@@ -16,9 +16,9 @@ import (
 
 var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = defaultShoot("default-")
+	f.Shoot = defaultShoot("hibernated-")
 
-	It("Create Shoot, Enable OIDC Extension, Delete Shoot", Label("good-case"), func() {
+	It("Create Shoot, Enable OIDC Extension, Hibernate and Delete Shoot", Label("good-case"), func() {
 		By("Create Shoot")
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()
@@ -41,6 +41,11 @@ var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 		one := int32(1)
 		Expect(*depl.Spec.Replicas).To(BeNumerically(">=", one))
 		Expect(depl.Status.ReadyReplicas).To(BeNumerically(">=", one))
+
+		By("Hibernate Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		defer cancel()
+		Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -9,9 +9,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	// imported test specs
-	_ "github.com/gardener/gardener-extension-shoot-oidc-service/test/e2e/lifecycle"
 )
 
 func TestE2E(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This moves all e2e test to the package `e2e_tests` and also fixes the handling of an error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
