### PR TITLE
Update golang and alpine versions

### DIFF
--- a/.test-defs/lifecycle.yaml
+++ b/.test-defs/lifecycle.yaml
@@ -18,4 +18,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-  image: golang:1.17.8
+  image: golang:1.17.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.17.8 AS builder
+FROM golang:1.17.9 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-oidc-service
 COPY . .
 RUN make install
 
 ############# gardener-extension-shoot-oidc-service
-FROM alpine:3.15.0 AS gardener-extension-shoot-oidc-service
+FROM alpine:3.15.4 AS gardener-extension-shoot-oidc-service
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-shoot-oidc-service /gardener-extension-shoot-oidc-service


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang and alpine versions
- golang to 1.17.9
- alpine to 3.15.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The golang version has been updated to 1.17.9.
```

```other operator
The alpine version has been updated to 3.15.4.
```
