### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make install
 
 ############# gardener-extension-shoot-oidc-service
-FROM alpine:3.15.4 AS gardener-extension-shoot-oidc-service
+FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-shoot-oidc-service
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-shoot-oidc-service /gardener-extension-shoot-oidc-service


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the base container image from `alpine` to `distroless`. This will reduce the attack surface of the image used to run the extension.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension now uses `distroless` instead of `alpine` as a base image.
```
