### PR TITLE
Change working directory to "/"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN make install
 
 ############# gardener-extension-shoot-oidc-service
 FROM gcr.io/distroless/static-debian11:nonroot AS gardener-extension-shoot-oidc-service
+WORKDIR /
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-shoot-oidc-service /gardener-extension-shoot-oidc-service


### PR DESCRIPTION
**What this PR does / why we need it**:
The default working directory of the nonroot user was `/home/nonroot`. Change this to `/` so that we prevent any issues with relative paths.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
