### PR TITLE
Remove go templates from manifest

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,16 +1,9 @@
 # SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
 #
 # SPDX-License-Identifier: Apache-2.0
-{{- $vers := Split .versions "," -}}
-{{ $defaultBranch := (index $vers 0) }}
 structure:
 - name: _index.md
-  source: https://github.com/gardener/gardener-extension-shoot-oidc-service/blob/{{$defaultBranch}}/README.md
+  source: /README.md
 - name: docs
-  nodes:
-  - nodesSelector:
-      path: https://github.com/gardener/gardener-extension-shoot-oidc-service/tree/{{$defaultBranch}}/docs
-links:
-  downloads:
-    scope:
-      "gardener/gardener-extension-shoot-oidc-service/(blob|raw)/(.*)/docs": ~
+  nodesSelector:
+    path: /docs


### PR DESCRIPTION
**What this PR does / why we need it**:
Update manifest file

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
