### PR TITLE
Update HPA version to v2 if k8s version is >= 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/gardener-extension-shoot-oidc-service
 go 1.18
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/gardener/gardener v1.53.0
 	github.com/go-logr/logr v1.2.3
@@ -23,7 +24,6 @@ require (
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -327,13 +327,15 @@ func getLabels() map[string]string {
 
 func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKubeconfigName, shootAccessSecretName, serverTLSSecretName string, k8sVersion *semver.Version) (map[string][]byte, error) {
 	var (
-		tcpProto         = corev1.ProtocolTCP
-		port10443        = intstr.FromInt(10443)
-		registry         = managedresources.NewRegistry(gardenerkubernetes.SeedScheme, gardenerkubernetes.SeedCodec, gardenerkubernetes.SeedSerializer)
-		requestCPU, _    = resource.ParseQuantity("50m")
-		limitCPU, _      = resource.ParseQuantity("1")
-		requestMemory, _ = resource.ParseQuantity("64Mi")
-		limitMemory, _   = resource.ParseQuantity("256Mi")
+		tcpProto                       = corev1.ProtocolTCP
+		port10443                      = intstr.FromInt(10443)
+		registry                       = managedresources.NewRegistry(gardenerkubernetes.SeedScheme, gardenerkubernetes.SeedCodec, gardenerkubernetes.SeedSerializer)
+		requestCPU, _                  = resource.ParseQuantity("50m")
+		limitCPU, _                    = resource.ParseQuantity("1")
+		requestMemory, _               = resource.ParseQuantity("64Mi")
+		limitMemory, _                 = resource.ParseQuantity("256Mi")
+		minReplicasHPA, maxReplicasHPA = int32(1), int32(3)
+		targetAverageUtilization       = int32(80)
 	)
 
 	kubeConfig := &configv1.Config{
@@ -493,7 +495,7 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 	}
 
 	if oidcReplicas != nil && *oidcReplicas > 0 {
-		err = registry.Add(buildHPA(namespace, k8sVersion, 1, 3, 80))
+		err = registry.Add(buildHPA(namespace, k8sVersion, minReplicasHPA, maxReplicasHPA, targetAverageUtilization))
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the version of `HorizontalPodAutoscaler` from `v2beta1` to `v2` when Seed k8s is >= 1.23. This change was needed since `v2beta1` will become deprecated in 1.26 https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`v2` of `HorizontalPodAutoscaler` cannot be used in versions of k8s < 1.23. When 1.23 becomes the minimal version for our Seeds this `if` statement will be removed and we will be using only `v2`

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`HorizontalPodAutoscaler` now uses v2 when seed k8s version is >= 1.23
```
