### PR TITLE
Update go version to 1.19.2

### DIFF
--- a/.test-defs/lifecycle.yaml
+++ b/.test-defs/lifecycle.yaml
@@ -18,4 +18,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-  image: golang:1.18.6
+  image: golang:1.19.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.18.6 AS builder
+FROM golang:1.19.2 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-oidc-service
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardener-extension-shoot-oidc-service
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/hack/test-e2e-provider-local.sh
+++ b/hack/test-e2e-provider-local.sh
@@ -15,7 +15,7 @@ if [[ ! -d "$repo_root/gardener" ]]; then
 fi
 
 cd "$repo_root/gardener"
-git checkout 30ce9c0f4d3fcbbfb496236b868eccc09a97defa
+git checkout f2c71f9da8072b1d907f13e5b8cd976607550b99
 make kind-up
 export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/kubeconfig
 make gardener-up

--- a/hack/test-e2e-provider-local.sh
+++ b/hack/test-e2e-provider-local.sh
@@ -15,7 +15,7 @@ if [[ ! -d "$repo_root/gardener" ]]; then
 fi
 
 cd "$repo_root/gardener"
-git checkout d829ed0913c02222f3a3ee7cdca2220fccb62ecb
+git checkout 30ce9c0f4d3fcbbfb496236b868eccc09a97defa
 make kind-up
 export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/kubeconfig
 make gardener-up


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension is now built using go version `1.19.2`.
```
