### PR TITLE
Update go version to 1.19.3

### DIFF
--- a/.test-defs/lifecycle.yaml
+++ b/.test-defs/lifecycle.yaml
@@ -18,4 +18,4 @@ spec:
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-  image: golang:1.19.2
+  image: golang:1.19.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.19.2 AS builder
+FROM golang:1.19.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-oidc-service
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension is now built using go version `1.19.3`.
```
