### PR TITLE
Fix scale down during hibernation

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -129,7 +129,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		return err
 	}
 
-	hibernated := controller.IsHibernated(cluster)
+	hibernated := controller.IsHibernationEnabled(cluster)
 	oidcReplicas, err := getOIDCReplicas(ctx, a.client, namespace, hibernated)
 	if err != nil {
 		return err

--- a/test/e2e/create_enable_hibernate_delete_test.go
+++ b/test/e2e/create_enable_hibernate_delete_test.go
@@ -47,6 +47,11 @@ var _ = Describe("OIDC Extension Tests", Label("OIDC"), func() {
 		defer cancel()
 		Expect(f.HibernateShoot(ctx, f.Shoot)).To(Succeed())
 
+		depl, err = getOIDCDeployment(ctx, seedClient.Client(), shootSeedNamespace)
+		Expect(err).NotTo(HaveOccurred())
+		zero := int32(0)
+		Expect(*depl.Spec.Replicas).To(BeNumerically("==", zero))
+
 		By("Delete Shoot")
 		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a regression introduced when vendoring g/g version containing gardener/gardener#6054.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
OWA now correctly scales to zero replicas during shoot hibernation.
```
