### PR TITLE
Use constant for ha config type label

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -16,6 +16,7 @@ import (
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	gardenerkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils"
@@ -329,8 +330,7 @@ func getLabels() map[string]string {
 
 func getHighAvailabilityLabel() map[string]string {
 	return map[string]string{
-		// TODO(timuthy): Use `HighAvailabilityConfigType` constant as soon as vendored to Gardener v1.60
-		"high-availability-config.resources.gardener.cloud/type": "server",
+		resourcesv1alpha1.HighAvailabilityConfigType: "server",
 	}
 }
 

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -330,7 +330,7 @@ func getLabels() map[string]string {
 
 func getHighAvailabilityLabel() map[string]string {
 	return map[string]string{
-		resourcesv1alpha1.HighAvailabilityConfigType: "server",
+		resourcesv1alpha1.HighAvailabilityConfigType: resourcesv1alpha1.HighAvailabilityConfigTypeServer,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses constant for ha config type label. Cleanup.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
