### PR TITLE
Make revendor command order fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,8 @@ docker-images:
 
 .PHONY: revendor
 revendor:
-	@GO111MODULE=on go mod vendor
 	@GO111MODULE=on go mod tidy
+	@GO111MODULE=on go mod vendor
 	@chmod +x $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/*
 	@chmod +x $(REPO_ROOT)/vendor/github.com/gardener/gardener/hack/.ci/*
 #	@$(REPO_ROOT)/hack/update-github-templates.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Run first `go mod tidy` and then `go mod vendor` like in [gardener's makefile](https://github.com/gardener/gardener/blob/master/Makefile#L196)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```
