### PR TITLE
Remove unused controller options

### DIFF
--- a/cmd/gardener-extension-shoot-oidc-service/app/app.go
+++ b/cmd/gardener-extension-shoot-oidc-service/app/app.go
@@ -80,7 +80,6 @@ func (o *Options) run(ctx context.Context) error {
 	ctrlConfig := o.oidcOptions.Completed()
 	ctrlConfig.ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)
 	ctrlConfig.Apply(&lifecycle.DefaultAddOptions.ServiceConfig)
-	o.controllerOptions.Completed().Apply(&lifecycle.DefaultAddOptions.ControllerOptions)
 	o.lifecycleOptions.Completed().Apply(&lifecycle.DefaultAddOptions.ControllerOptions)
 	o.healthOptions.Completed().Apply(&healthcheck.DefaultAddOptions.Controller)
 	o.heartbeatOptions.Completed().Apply(&heartbeat.DefaultAddOptions)

--- a/cmd/gardener-extension-shoot-oidc-service/app/options.go
+++ b/cmd/gardener-extension-shoot-oidc-service/app/options.go
@@ -23,7 +23,6 @@ type Options struct {
 	oidcOptions        *oidccmd.OIDCServiceOptions
 	restOptions        *controllercmd.RESTOptions
 	managerOptions     *controllercmd.ManagerOptions
-	controllerOptions  *controllercmd.ControllerOptions
 	lifecycleOptions   *controllercmd.ControllerOptions
 	healthOptions      *controllercmd.ControllerOptions
 	controllerSwitches *controllercmd.SwitchOptions
@@ -63,10 +62,6 @@ func NewOptions() *Options {
 			MetricsBindAddress:      ":8080",
 			HealthBindAddress:       ":8081",
 		},
-		controllerOptions: &controllercmd.ControllerOptions{
-			// This is a default value.
-			MaxConcurrentReconciles: 5,
-		},
 		lifecycleOptions: &controllercmd.ControllerOptions{
 			// This is a default value.
 			MaxConcurrentReconciles: 5,
@@ -91,7 +86,6 @@ func NewOptions() *Options {
 		options.oidcOptions,
 		options.restOptions,
 		options.managerOptions,
-		options.controllerOptions,
 		controllercmd.PrefixOption("lifecycle-", options.lifecycleOptions),
 		controllercmd.PrefixOption("healthcheck-", options.healthOptions),
 		controllercmd.PrefixOption("heartbeat-", options.heartbeatOptions),


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes unused controller options. Thanks for reporting @Kostov6 !
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
