### PR TITLE
Use `gardener@v1.69.1` for e2e tests

### DIFF
--- a/hack/test-e2e-provider-local.sh
+++ b/hack/test-e2e-provider-local.sh
@@ -15,7 +15,7 @@ if [[ ! -d "$repo_root/gardener" ]]; then
 fi
 
 cd "$repo_root/gardener"
-git checkout d141e381525130d9ad5c72a1ad52fcc561f9bf00 # g/g v1.65.1
+git checkout 1a7052b51f76c8f317be3dd8d91b420afdb611f3 # g/g v1.69.1
 make kind-up
 export KUBECONFIG=$repo_root/gardener/example/gardener-local/kind/local/kubeconfig
 make gardener-up


### PR DESCRIPTION
**What this PR does / why we need it**:
The prow cluster is using Gardenlinux 934 worker groups now, so `cgroupv2` support for docker-in-docker is required. 
This is available in `gardener@v1.69.1`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
