### PR TITLE
Fix call to prepare_release script

### DIFF
--- a/.ci/prepare_release
+++ b/.ci/prepare_release
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"$(dirname $0)"/hack/prepare_release "$(dirname $0)"/.. "$(dirname $0)"/.. github.com/gardener gardener-extension-shoot-oidc-service
+"$(dirname $0)"/hack/prepare_release "$(dirname $0)"/.. github.com/gardener gardener-extension-shoot-oidc-service


### PR DESCRIPTION
**What this PR does / why we need it**:
Call `prepare_release` with the correct number of arguments https://github.com/gardener/gardener-extension-shoot-oidc-service/blob/810d8c118eb1f01c04856ce304489946a8b48bb9/.ci/hack/prepare_release#L19
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
