### PR TITLE
Increase mem limit of OWA deployment

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -345,7 +345,7 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 		requestCPU, _    = resource.ParseQuantity("50m")
 		limitCPU, _      = resource.ParseQuantity("1")
 		requestMemory, _ = resource.ParseQuantity("64Mi")
-		limitMemory, _   = resource.ParseQuantity("256Mi")
+		limitMemory, _   = resource.ParseQuantity("1Gi")
 	)
 
 	kubeConfig := &configv1.Config{

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -339,13 +339,17 @@ func getHighAvailabilityLabel() map[string]string {
 
 func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKubeconfigName, shootAccessSecretName, serverTLSSecretName string, k8sVersion *semver.Version) (map[string][]byte, error) {
 	var (
-		int10443         = int32(10443)
-		port10443        = intstr.FromInt32(int10443)
-		registry         = managedresources.NewRegistry(gardenerkubernetes.SeedScheme, gardenerkubernetes.SeedCodec, gardenerkubernetes.SeedSerializer)
-		requestCPU, _    = resource.ParseQuantity("50m")
-		limitCPU, _      = resource.ParseQuantity("1")
-		requestMemory, _ = resource.ParseQuantity("64Mi")
-		limitMemory, _   = resource.ParseQuantity("1Gi")
+		int10443      = int32(10443)
+		port10443     = intstr.FromInt32(int10443)
+		registry      = managedresources.NewRegistry(gardenerkubernetes.SeedScheme, gardenerkubernetes.SeedCodec, gardenerkubernetes.SeedSerializer)
+		requestCPU    = resource.MustParse("50m")
+		requestMemory = resource.MustParse("64Mi")
+		// Keep in sync with GOMAXPROCS env variable set to the OWA container
+		// If cpu limit is > 1 round up GOMAXPROCS and set it to 1 otherwise
+		limitCPU = resource.MustParse("1")
+		// Keep in sync with GOMEMLIMIT env variable set to the OWA container.
+		// GOMEMLIMIT should be around 80-90% of the memory limit
+		limitMemory = resource.MustParse("1Gi")
 	)
 
 	kubeConfig := &configv1.Config{

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -461,6 +461,10 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 							PeriodSeconds:       20,
 							FailureThreshold:    3,
 						},
+						Env: []corev1.EnvVar{
+							{Name: "GOMAXPROCS", Value: "1"},      // in sync with the CPU limits
+							{Name: "GOMEMLIMIT", Value: "920MiB"}, // roughly 90% of 1Gi
+						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    requestCPU,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the memory limit of OWA deployment to `1Gi` and also sets GOMAXPROCS & GOMEMLIMIT.

See https://www.riverphillips.dev/blog/go-cfs/ and https://hsleep.medium.com/optimizing-memory-management-in-go-with-gomemlimit-da8ed23e2dcb for motivation on setting the two env variables. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
