### PR TITLE
Dependabot update only g/g dependency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
 - package-ecosystem: docker
   directory: /
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:
A lot of the dependencies of this repo are updated with g/g anyways. This PR basically applies the suggestion from https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/150#discussion_r1476280975

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
