### PR TITLE
Lower cpu and memory requests for OWA

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -346,8 +346,8 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 		int10443      = int32(10443)
 		port10443     = intstr.FromInt32(int10443)
 		registry      = managedresources.NewRegistry(gardenerkubernetes.SeedScheme, gardenerkubernetes.SeedCodec, gardenerkubernetes.SeedSerializer)
-		requestCPU    = resource.MustParse("50m")
-		requestMemory = resource.MustParse("64Mi")
+		requestCPU    = resource.MustParse("10m")
+		requestMemory = resource.MustParse("32Mi")
 		// Keep in sync with GOMAXPROCS env variable set to the OWA container
 		// If cpu limit is > 1 round up GOMAXPROCS and set it to 1 otherwise
 		limitCPU = resource.MustParse("1")


### PR DESCRIPTION
**What this PR does / why we need it**:
Lower the initial requests used for the OWA deployment.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
OWA is now deployed with lower cpu and memory requests - 10m and 32Mi respectively.
```
