### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gardener-extension-shoot-oidc-service:
+  templates:
+    helmcharts:
+    - &shoot-oidc-service
+      name: shoot-oidc-service
+      dir: charts/gardener-extension-shoot-oidc-service
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-shoot-oidc-service.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-shoot-oidc-service.tag
+        attribute: image.tag
+
   base_definition:
     traits:
       version:
@@ -28,6 +40,9 @@ gardener-extension-shoot-oidc-service:
         draft_release: ~
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-oidc-service
     pull-request:
       traits:
         pull-request: ~
@@ -36,6 +51,9 @@ gardener-extension-shoot-oidc-service:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-oidc-service
     release:
       traits:
         version:
@@ -47,6 +65,9 @@ gardener-extension-shoot-oidc-service:
             gardener-extension-shoot-oidc-service:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/shoot-oidc-service
               tag_as_latest: true
+          helmcharts:
+          - <<: *shoot-oidc-service
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
         release:
           nextversion: 'bump_minor'
           next_version_callback: '.ci/prepare_release'


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
