### PR TITLE
Add object selector to extension webhook

### DIFF
--- a/pkg/webhook/kapiserver/webhook.go
+++ b/pkg/webhook/kapiserver/webhook.go
@@ -58,9 +58,9 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		NamespaceSelector: namespaceSelector,
 		ObjectSelector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"gardener.cloud/role": "controlplane",
-				"app":                 "kubernetes",
-				"role":                "apiserver",
+				v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+				v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+				v1beta1constants.LabelRole:  v1beta1constants.LabelAPIServer,
 			},
 		},
 	}

--- a/pkg/webhook/kapiserver/webhook.go
+++ b/pkg/webhook/kapiserver/webhook.go
@@ -56,6 +56,13 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:              "oidc",
 		Webhook:           &admission.Webhook{Handler: handler},
 		NamespaceSelector: namespaceSelector,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"gardener.cloud/role": "controlplane",
+				"app":                 "kubernetes",
+				"role":                "apiserver",
+			},
+		},
 	}
 
 	return webhook, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Related to https://github.com/gardener/gardener/issues/9864

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The extension mutating webhook now uses object selector to reduce the number of calls.
```
