### PR TITLE
[dependabot] Merge two docker ecosystems into one

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,10 +8,8 @@ updates:
   allow:
   - dependency-name: "github.com/gardener/gardener"
 - package-ecosystem: docker
-  directory: /
-  schedule:
-    interval: daily
-- package-ecosystem: docker
-  directory: /.test-defs
+  directories:
+  - /
+  - /.test-defs
   schedule:
     interval: daily


### PR DESCRIPTION
**What this PR does / why we need it**:
With this change we should get single PR to update the golang instead of two like
- https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/226, and
- https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/225

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
