### PR TITLE
Added Responsibles in images.yaml

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -38,6 +38,13 @@ gardener-extension-shoot-oidc-service:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/shoot-oidc-service
             dockerfile: 'Dockerfile'
             target: gardener-extension-shoot-oidc-service
+            resource_labels:
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubUser'
+                username: 'dimityrmirchev'
+              - type: 'githubUser'
+                username: 'vpnachev'
   jobs:
     head-update:
       traits:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,4 +7,11 @@ images:
 - name: oidc-webhook-authenticator
   sourceRepository: github.com/gardener/oidc-webhook-authenticator
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator
-  tag: "v0.33.0"
+  tag: "v0.33.0"  
+  labels:
+  - name: 'cloud.gardener.cnudie/responsibles'
+    value:
+    - type: 'githubUser'
+      username: 'dimityrmirchev'
+    - type: 'githubUser'
+      email: 'vpnachev'

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
 - name: oidc-webhook-authenticator
   sourceRepository: github.com/gardener/oidc-webhook-authenticator
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/oidc-webhook-authenticator
-  tag: "v0.33.0"  
+  tag: "v0.33.0"
   labels:
   - name: 'cloud.gardener.cnudie/responsibles'
     value:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add  `cloud.gardener.cnudie/responsibles` label

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
