### PR TITLE
Simplify controller and mutation flows

### DIFF
--- a/hack/oidc-up.sh
+++ b/hack/oidc-up.sh
@@ -19,6 +19,11 @@ cp -f $repo_root/example/controller-registration.yaml $repo_root/tmp/controller-
 yq -i e "(select (.helm.values.image) | .helm.values.image.tag) |= \"$version\"" $repo_root/tmp/controller-registration.yaml
 yq -i e '(select (.helm.values.image) | .helm.values.image.repository) |= "docker.io/library/shoot-oidc-service-local"' $repo_root/tmp/controller-registration.yaml
 
+# --server-side apply is a workaround for https://github.com/gardener/gardener/issues/10267.
+# kubectl apply attempts a strategic merge patch which fails for a ControllerDeployment.
+# For more details, see https://github.com/gardener/gardener/issues/10267.
+#
+# TODO: Remove `--server-side` and `--force-conflicts` flags when the above issue is resolved.
 kubectl apply -f "$repo_root/tmp/controller-registration.yaml" \
     --server-side \
     --force-conflicts

--- a/hack/oidc-up.sh
+++ b/hack/oidc-up.sh
@@ -19,4 +19,6 @@ cp -f $repo_root/example/controller-registration.yaml $repo_root/tmp/controller-
 yq -i e "(select (.helm.values.image) | .helm.values.image.tag) |= \"$version\"" $repo_root/tmp/controller-registration.yaml
 yq -i e '(select (.helm.values.image) | .helm.values.image.repository) |= "docker.io/library/shoot-oidc-service-local"' $repo_root/tmp/controller-registration.yaml
 
-kubectl apply -f "$repo_root/tmp/controller-registration.yaml"
+kubectl apply -f "$repo_root/tmp/controller-registration.yaml" \
+    --server-side \
+    --force-conflicts

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -171,7 +171,6 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 	seedResources, err := getSeedResources(
 		oidcReplicas,
-		hibernated,
 		namespace,
 		extensions.GenericTokenKubeconfigSecretNameFromCluster(cluster),
 		oidcShootAccessSecret.Secret.Name,
@@ -341,7 +340,7 @@ func getHighAvailabilityLabel() map[string]string {
 	}
 }
 
-func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKubeconfigName, shootAccessSecretName, serverTLSSecretName string, k8sVersion *semver.Version) (map[string][]byte, error) {
+func getSeedResources(oidcReplicas *int32, namespace, genericKubeconfigName, shootAccessSecretName, serverTLSSecretName string, k8sVersion *semver.Version) (map[string][]byte, error) {
 	var (
 		int10443      = int32(10443)
 		port10443     = intstr.FromInt32(int10443)
@@ -496,22 +495,6 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 		return nil, err
 	}
 
-	if !hibernated {
-		err = registry.Add(&corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      constants.WebhookKubeConfigSecretName,
-				Namespace: namespace,
-				Labels:    getLabels(),
-			},
-			Data: map[string][]byte{
-				"kubeconfig": kubeAPIServerKubeConfig,
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        constants.ApplicationName,
@@ -571,6 +554,16 @@ func getSeedResources(oidcReplicas *int32, hibernated bool, namespace, genericKu
 		buildVPA(namespace),
 		service,
 		serviceMonitor,
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constants.WebhookKubeConfigSecretName,
+				Namespace: namespace,
+				Labels:    getLabels(),
+			},
+			Data: map[string][]byte{
+				"kubeconfig": kubeAPIServerKubeConfig,
+			},
+		},
 	)
 
 	if err != nil {

--- a/pkg/webhook/kapiserver/ensurer.go
+++ b/pkg/webhook/kapiserver/ensurer.go
@@ -56,7 +56,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, _ gcontext.
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: constants.WebhookKubeConfigSecretName, Namespace: newDeployment.Namespace}}
 		if err := e.client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 			if apierrors.IsNotFound(err) {
-				log.Info("Authentication kubeconfig secret is not yet created, skipping mutation of kube-apiserver deployment")
+				log.Info("Authentication token webhook config secret is not yet created, skipping mutation of kube-apiserver deployment")
 				return nil
 			}
 

--- a/pkg/webhook/kapiserver/ensurer.go
+++ b/pkg/webhook/kapiserver/ensurer.go
@@ -9,7 +9,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
@@ -51,40 +50,27 @@ var NewSecretsManager = extensionssecretsmanager.SecretsManagerForCluster
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, _ gcontext.GardenContext, newDeployment, _ *appsv1.Deployment) error {
 	template := &newDeployment.Spec.Template
 	ps := &template.Spec
+	log := e.logger.WithValues("namespace", newDeployment.Namespace)
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, v1beta1constants.DeploymentNameKubeAPIServer); c != nil {
-		if newDeployment.Status.ReadyReplicas <= 0 {
-			return nil
-		}
-
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: constants.WebhookKubeConfigSecretName, Namespace: newDeployment.Namespace}}
 		if err := e.client.Get(ctx, client.ObjectKeyFromObject(secret), secret); err != nil {
 			if apierrors.IsNotFound(err) {
+				log.Info("Authentication kubeconfig secret is not yet created, skipping mutation of kube-apiserver deployment")
 				return nil
 			}
-			return err
-		}
 
-		cluster, err := controller.GetCluster(ctx, e.client, newDeployment.Namespace)
-		if err != nil {
 			return err
-		}
-
-		if controller.IsHibernated(cluster) {
-			return nil
 		}
 
 		// we expect that the CA bundle secret is handled by the lifecycle controller
 		caBundleSecret, err := getLatestIssuedCABundleSecret(ctx, e.client, newDeployment.Namespace)
 		if err != nil {
-			// if CA secret is still not created we do not want to return an error
-			if _, ok := err.(*noCASecretError); ok {
-				return nil
-			}
 			return err
 		}
 
 		ensureKubeAPIServerIsMutated(ps, c, caBundleSecret.Name)
+		log.Info("It is ensured kube-apiserver is configured to use the extension")
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify controller and mutation flows. Since #173 owa is not authenticating itself in front of the kube-apiserver, therefore the deadlock fixed with #28 cannot happen anymore, i.e. the extension and admission controllers does not have to handle specifically the case when the cluster is hibernated.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
