### PR TITLE
Enhance KubeAPIServer ensurer to use container Args instead of Command

### DIFF
--- a/test/e2e/create_enable_disrupt_reconcile_delete_test.go
+++ b/test/e2e/create_enable_disrupt_reconcile_delete_test.go
@@ -87,7 +87,7 @@ func breakAPIServerDepl(ctx context.Context, c client.Client, namespace string) 
 	}
 	for i, v := range kubeAPIServerDepl.Spec.Template.Spec.Containers {
 		if v.Name == "kube-apiserver" {
-			kubeAPIServerDepl.Spec.Template.Spec.Containers[i].Command = append(kubeAPIServerDepl.Spec.Template.Spec.Containers[i].Command, "--hello-world=invalid-flag")
+			kubeAPIServerDepl.Spec.Template.Spec.Containers[i].Args = append(kubeAPIServerDepl.Spec.Template.Spec.Containers[i].Args, "--hello-world=invalid-flag")
 			break
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance KubeAPIServer ensurer to use container Args instead of Command

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
