### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.28

### DIFF
--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -175,7 +175,7 @@ spec:
         - --service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa
         - --service-account-key-file=/srv/kubernetes/service-account-key-bundle/bundle.key
         - --v=2
-        image: registry.k8s.io/kube-apiserver:v1.28.2
+        image: registry.k8s.io/kube-apiserver:v1.32.0
         imagePullPolicy: IfNotPresent
         name: kube-apiserver
         securityContext:

--- a/example/30-cluster.yaml
+++ b/example/30-cluster.yaml
@@ -24,7 +24,7 @@ spec:
       dns:
         domain: foo.bar.example.com
       kubernetes:
-        version: 1.28.2
+        version: 1.32.0
       resources:
         - name: issuer-custom-eab-hmackey
           resourceRef:

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -60,7 +60,7 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			SecretBindingName: ptr.To("local"),
 			CloudProfile:      &gardencorev1beta1.CloudProfileReference{Name: "local"},
 			Kubernetes: gardencorev1beta1.Kubernetes{
-				Version: "1.28.2",
+				Version: "1.32.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
 					SerializeImagePulls: ptr.To(false),
 					RegistryPullQPS:     ptr.To[int32](10),

--- a/test/e2e/common_test.go
+++ b/test/e2e/common_test.go
@@ -18,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,9 +55,11 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{
-			Region:            "local",
+			CloudProfile: &gardencorev1beta1.CloudProfileReference{
+				Name: "local",
+			},
 			SecretBindingName: ptr.To("local"),
-			CloudProfile:      &gardencorev1beta1.CloudProfileReference{Name: "local"},
+			Region:            "local",
 			Kubernetes: gardencorev1beta1.Kubernetes{
 				Version: "1.32.0",
 				Kubelet: &gardencorev1beta1.KubeletConfig{
@@ -66,12 +67,10 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 					RegistryPullQPS:     ptr.To[int32](10),
 					RegistryBurst:       ptr.To[int32](20),
 				},
-				KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 			},
 			Networking: &gardencorev1beta1.Networking{
-				Type:           ptr.To("calico"),
-				Nodes:          ptr.To("10.10.0.0/16"),
-				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"calico.networking.extensions.gardener.cloud/v1alpha1","kind":"NetworkConfig","typha":{"enabled":false},"backend":"none"}`)},
+				Type:  ptr.To("calico"),
+				Nodes: ptr.To("10.10.0.0/16"),
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",


### PR DESCRIPTION
**What this PR does / why we need it**:
Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.28.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12409

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`shoot-oidc-service` no longer supports Shoots with Кubernetes version <= 1.28.
```
